### PR TITLE
Examples do not compile on jdk9+

### DIFF
--- a/arbiter-examples/pom.xml
+++ b/arbiter-examples/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
     </dependencies>

--- a/arbiter-examples/pom.xml
+++ b/arbiter-examples/pom.xml
@@ -43,6 +43,12 @@
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Force guava versions for using Arbiter UI -->
@@ -58,6 +64,14 @@
             <artifactId>arbiter-deeplearning4j</artifactId>
             <version>${arbiter.version}</version>
         </dependency>
+
+        <!-- java9 compatbile version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/arbiter-examples/pom.xml
+++ b/arbiter-examples/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
     </dependencies>

--- a/datavec-examples/pom.xml
+++ b/datavec-examples/pom.xml
@@ -29,11 +29,10 @@
             </exclusions>
         </dependency>
 
-        <!-- java9 compatbile version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
         <dependency>

--- a/datavec-examples/pom.xml
+++ b/datavec-examples/pom.xml
@@ -29,10 +29,11 @@
             </exclusions>
         </dependency>
 
+        <!-- java9 compatbile version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
         <dependency>

--- a/datavec-examples/pom.xml
+++ b/datavec-examples/pom.xml
@@ -21,6 +21,18 @@
             <groupId>org.datavec</groupId>
             <artifactId>datavec-api</artifactId>
             <version>${datavec.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
         </dependency>
 
         <dependency>

--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -101,11 +101,11 @@
             <artifactId>${nd4j.backend}</artifactId>
         </dependency>
 
-        <!-- java9 compatbile version of lombok -->
+		<!-- java9 compatible version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
 

--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -101,11 +101,11 @@
             <artifactId>${nd4j.backend}</artifactId>
         </dependency>
 
-		<!-- java9 compatible version of lombok -->
+        <!-- java9 compatbile version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
 

--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -79,6 +79,12 @@
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
@@ -94,6 +100,15 @@
             <groupId>org.nd4j</groupId>
             <artifactId>${nd4j.backend}</artifactId>
         </dependency>
+
+		<!-- java9 compatible version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -71,19 +71,52 @@
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-nlp</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <!-- java9 compatbile version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
+        </dependency>
+
 
         <!-- deeplearning4j-ui is used for HistogramIterationListener + visualization: see http://deeplearning4j.org/visualization -->
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-ui_2.10</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.jodah</groupId>
+                    <artifactId>typetools</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/net.jodah/typetools -->
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>0.5.0</version>
         </dependency>
 
         <!-- Force guava versions for using UI/HistogramIterationListener -->
@@ -185,6 +218,12 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>8.7.0</version>
             </plugin>
         </plugins>
     </build>

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
 

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
 

--- a/dl4j-spark-examples/dl4j-spark/pom.xml
+++ b/dl4j-spark-examples/dl4j-spark/pom.xml
@@ -25,6 +25,19 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-native-platform</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+		<!-- java9 comptabible version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
         </dependency>
 
         <dependency>
@@ -32,6 +45,10 @@
             <artifactId>dl4j-spark_${scala.binary.version}</artifactId>
             <version>${dl4j.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
                 <exclusion>
                     <artifactId>spark-core_2.10</artifactId>
                     <groupId>org.apache.spark</groupId>

--- a/dl4j-spark-examples/dl4j-spark/pom.xml
+++ b/dl4j-spark-examples/dl4j-spark/pom.xml
@@ -33,11 +33,11 @@
             </exclusions>
         </dependency>
 
-		<!-- java9 comptabible version of lombok -->
+        <!-- java9 compatbile version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
         <dependency>

--- a/dl4j-spark-examples/dl4j-spark/pom.xml
+++ b/dl4j-spark-examples/dl4j-spark/pom.xml
@@ -33,11 +33,11 @@
             </exclusions>
         </dependency>
 
-        <!-- java9 compatbile version of lombok -->
+		<!-- java9 comptabible version of lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
         <dependency>

--- a/nd4j-examples/pom.xml
+++ b/nd4j-examples/pom.xml
@@ -18,6 +18,19 @@
             <groupId>org.nd4j</groupId>
             <artifactId>${nd4j.backend}</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- java9 compatbile version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
         </dependency>
 
         <!-- Copy this into your own projects (without the comment block around it), for CPU operations-->
@@ -46,5 +59,27 @@
 
 
     </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>8.7.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>

--- a/nd4j-examples/pom.xml
+++ b/nd4j-examples/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
         <!-- Copy this into your own projects (without the comment block around it), for CPU operations-->

--- a/nd4j-examples/pom.xml
+++ b/nd4j-examples/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
         <!-- Copy this into your own projects (without the comment block around it), for CPU operations-->

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven.minimum.version>3.3.1</maven.minimum.version>
+        <lombok.version>1.6.18</lombok.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven.minimum.version>3.3.1</maven.minimum.version>
-        <lombok.version>1.6.18</lombok.version>
     </properties>
 
     <modules>

--- a/rl4j-examples/pom.xml
+++ b/rl4j-examples/pom.xml
@@ -68,6 +68,12 @@
             <groupId>org.deeplearning4j</groupId>
             <artifactId>rl4j-core</artifactId>
             <version>${rl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
@@ -85,6 +91,14 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
+
+        <!-- java9 compatbile version of lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/rl4j-examples/pom.xml
+++ b/rl4j-examples/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
         </dependency>
 
     </dependencies>

--- a/rl4j-examples/pom.xml
+++ b/rl4j-examples/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>1.16.18</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Some of the jvm internal api used by project Lombok was removed so I updated to a newer version.

For details on Lombok fixes please visit: https://github.com/rzwitserloot/lombok/issues/985